### PR TITLE
Update OBSStudio filename to include architecture

### DIFF
--- a/Evergreen/Manifests/OBSStudio.json
+++ b/Evergreen/Manifests/OBSStudio.json
@@ -13,7 +13,7 @@
         },
         "Download": {
             "Uri": "https://cdn-fastly.obsproject.com/downloads/#FileName",
-            "FileName": "OBS-Studio-#Version-Windows-Installer.exe",
+            "FileName": "OBS-Studio-#Version-Windows-#Architecture-Installer.exe",
             "Architectures": [
                 "x64"
             ],


### PR DESCRIPTION
OBS have updated their file naming again. Now includes architecture again likely leading up to the eventual stable release for arm64 builds.